### PR TITLE
Fixed incorrect nonce checking inequality

### DIFF
--- a/src/oracle/tss-sign/signer.js
+++ b/src/oracle/tss-sign/signer.js
@@ -291,7 +291,7 @@ async function consumer(msg) {
   }
   const account = await getAccount(from)
 
-  if (nonce > account.sequence) {
+  if (nonce < account.sequence) {
     logger.debug('Tx has been already sent')
     logger.info('Acking message (skipped nonce)')
     channel.ack(msg)


### PR DESCRIPTION
In case when oracle starts generating signature for an already sent transaction, current transaction nonce should be skipped. Previous version handled this case incorrectly.